### PR TITLE
removed a warning

### DIFF
--- a/lib/Text/Textile.pm
+++ b/lib/Text/Textile.pm
@@ -1556,8 +1556,8 @@ sub format_image {
         }
         if (!$pctw && !$pcth) {
             ($w,$h) = ($extra =~ m/(^|\s)(\d+|\*)x(\d+|\*)(\s|$)/)[1,2];
-            $w = '' if $w eq '*';
-            $h = '' if $h eq '*';
+            $w = '' if $w && $w eq '*';
+            $h = '' if $h && $h eq '*';
             if (!$w) {
                 ($w) = ($extra =~ m/(^|[,\s])(\d+)w([\s,]|$)/)[1];
             }

--- a/t/image.t
+++ b/t/image.t
@@ -1,0 +1,20 @@
+#!/usr/bin/perl -w
+
+use warnings;
+use strict;
+use Test::More tests=>1;
+use Text::Textile qw(textile);
+
+my $source = <<'SOURCE';
+this is an !/image/1853561/display(Image)! yay
+SOURCE
+
+my $dest = textile($source);
+$dest =~ s/(^\s+|\s+$)//g;
+
+my $expected = <<'EXPECTED';
+<p>this is an <img src="/image/1853561/display" alt="Image" /> yay</p>
+EXPECTED
+$expected =~ s/(^\s+|\s+$)//g;
+
+is($dest, $expected);


### PR DESCRIPTION
Hi!

Rendering an image sometimes caused warnings:
Use of uninitialized value $w in string eq at /home/domm/perl/other/text-textile/lib/Text/Textile.pm line 1559.
Use of uninitialized value $h in string eq at /home/domm/perl/other/text-textile/lib/Text/Textile.pm line 1560.

My first commit adds a rather simple test to render an image which shows the warnings
The second commit fixes the code that causes the warning.

Please apply if you like it...
