### PR TITLE
improve whitespace handling in image processing

### DIFF
--- a/lib/Text/Textile.pm
+++ b/lib/Text/Textile.pm
@@ -882,7 +882,7 @@ sub format_inline {
                ($imgalignre?)              # $2: optional alignment
                ($clstypadre*)              # $3: optional CSS class/id
                ($imgalignre?)              # $4: optional alignment
-               (?:\s*)                     # space between alignment/css stuff
+               (?:(?<=[^\!])\s+)?          # optional space between alignment/css stuff
                ([^\s\(\!]+)                # $5: filename
                (\s*[^\(\!]*(?:\([^\)]+\))?[^\!]*) # $6: extras (alt text)
                \!                          # closing

--- a/t/image.t
+++ b/t/image.t
@@ -7,13 +7,16 @@ use Text::Textile qw(textile);
 
 my $source = <<'SOURCE';
 this is an !/image/1853561/display(Image)! yay
+But this ! is no image ! is it?
 SOURCE
 
 my $dest = textile($source);
 $dest =~ s/(^\s+|\s+$)//g;
 
 my $expected = <<'EXPECTED';
-<p>this is an <img src="/image/1853561/display" alt="Image" /> yay</p>
+<p>this is an <img src="/image/1853561/display" alt="Image" /> yay<br />
+But this ! is no image ! is it?</p>
+
 EXPECTED
 $expected =~ s/(^\s+|\s+$)//g;
 


### PR DESCRIPTION
Hi Brad,

thank you for your work on Text::Textile.

We love your module and impressed by your regex skills. However we feel that we found a bug in the image parsing part.

Please check an hopefully apply the patch if you agree with my version.

NB: I have not checked other tags for the same issue ...

Best regards and Happy Easter!
Serap

prevent images parser from interpreting ! noimage ! as image tag

(?:(?<=[^!])\s+)?

optionally match one or more spaces that must not be preceeded by an
exclamation mark. if any of the optional alignment or css options are
used a space is acceptable otherwise not.
