### PR TITLE
Expand entity regexp

### DIFF
--- a/lib/Text/Textile.pm
+++ b/lib/Text/Textile.pm
@@ -905,7 +905,7 @@ sub format_inline {
     $text = $self->encode_html($text);
     $text =~ s!&lt;textile#(\d+)&gt;!<textile#$1>!g;
     $text =~ s!&amp;quot;!&#34;!g;
-    $text =~ s!&amp;(([a-zA-Z0-9]+|#\d+);)!&$1!g;
+    $text =~ s!&amp;(([a-zA-Z0-9]+|#\d+|#x[0-9A-Fa-f]+);)!&$1!g;
     $text =~ s!&quot;!"!g; #"
 
     # These create markup with entities. Do first and 'save' result for later:

--- a/lib/Text/Textile.pm
+++ b/lib/Text/Textile.pm
@@ -905,7 +905,7 @@ sub format_inline {
     $text = $self->encode_html($text);
     $text =~ s!&lt;textile#(\d+)&gt;!<textile#$1>!g;
     $text =~ s!&amp;quot;!&#34;!g;
-    $text =~ s!&amp;(([a-z]+|#\d+);)!&$1!g;
+    $text =~ s!&amp;(([a-zA-Z0-9]+|#\d+);)!&$1!g;
     $text =~ s!&quot;!"!g; #"
 
     # These create markup with entities. Do first and 'save' result for later:

--- a/t/09html_entities.t
+++ b/t/09html_entities.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl -Tw
+
+use warnings;
+use strict;
+use Test::More tests=>3;
+use Text::Textile qw(textile);
+
+my $source = <<'SOURCE';
+&oslash;
+SOURCE
+
+my $dest = textile($source);
+$dest =~ s/(^\s+|\s+$)//g;
+
+my $expected = <<'EXPECTED';
+<p>&oslash;</p>
+EXPECTED
+$expected =~ s/(^\s+|\s+$)//g;
+
+is($dest, $expected, 'Preserve lowercase html entity?');
+
+$source = <<'SOURCE';
+&Oslash;
+SOURCE
+
+$dest = textile($source);
+$dest =~ s/(^\s+|\s+$)//g;
+
+$expected = <<'EXPECTED';
+<p>&Oslash;</p>
+EXPECTED
+$expected =~ s/(^\s+|\s+$)//g;
+
+is($dest, $expected, 'Preserve mixed-case html entity');
+
+$source = <<'SOURCE';
+&frac14;
+SOURCE
+
+$dest = textile($source);
+$dest =~ s/(^\s+|\s+$)//g;
+
+$expected = <<'EXPECTED';
+<p>&frac14;</p>
+EXPECTED
+$expected =~ s/(^\s+|\s+$)//g;
+
+is($dest, $expected, 'Preserve html entity with number');

--- a/t/09html_entities.t
+++ b/t/09html_entities.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests=>3;
+use Test::More tests=>4;
 use Text::Textile qw(textile);
 
 my $source = <<'SOURCE';
@@ -46,3 +46,17 @@ EXPECTED
 $expected =~ s/(^\s+|\s+$)//g;
 
 is($dest, $expected, 'Preserve html entity with number');
+
+$source = <<'SOURCE';
+&#x1E54;
+SOURCE
+
+$dest = textile($source);
+$dest =~ s/(^\s+|\s+$)//g;
+
+$expected = <<'EXPECTED';
+<p>&#x1E54;</p>
+EXPECTED
+$expected =~ s/(^\s+|\s+$)//g;
+
+is($dest, $expected, 'Preserve hexadecimal html entity');


### PR DESCRIPTION
Support mixed-case html entites, such as the capital letter Oslash and numerical entities in hexadecimal
